### PR TITLE
reset the api key after each spec example run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,9 @@ require 'shipcloud'
 require 'rspec'
 require "webmock/rspec"
 require "pry"
+
+RSpec.configure do |config|
+  config.after(:each) do
+    Shipcloud.api_key = nil
+  end
+end


### PR DESCRIPTION
Reset the api key after each spec example run to prevent side effects
in other specs
