### PR TITLE
add the possibility to specify the api key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.1.7
   - 2.2.4
   - 2.3.0
-  - jruby-9.0.0.0
   - rbx-2
 notifications:
   flowdock:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 ### Added
-
+- Add the possibility to specify the api key on every request. (#8)
 ### Removed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
 ### Added
 - Add the possibility to specify the api key on every request. (#8)
+
 ### Removed
+- Removed the following ruby versions from travis-ci test runs:
+  - jruby-9.0.0.0
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,34 @@ Or install it yourself as:
 
 ## Usage
 
-Before using the shipcloud API, you need to set the API access key:
+Before using the shipcloud API, you may want to set the API access key.
 
-```
+```ruby
 Shipcloud.api_key = 'your-api-key-goes-here'
 ```
 
 Since Version 0.4.0, you can also do this via a configuration block, e.g. in an initializer:
 
-```
+```ruby
 Shipcloud.configure do |config|
   config.api_key = 'your-api-key-goes-here'
 end
 ```
+
+You can also pass the API key with each request:
+```ruby
+ Shipcloud::Shipment.create(
+   {
+     carrier: 'ups',
+     from: from-address-params,
+     to: to-address-params,
+     package: package-params,
+     create_shipping_label: true
+   },
+  api_key: "your-api-key"
+ )
+```
+If you pass in the ```api_key``` option, the value will be used as API key for the current request, even if you have set the ```Shipcloud.api_key``` before.
 
 You can sign up for a developer account at *[shipcloud.io](http://www.shipcloud.io)*
 
@@ -40,7 +55,7 @@ You can sign up for a developer account at *[shipcloud.io](http://www.shipcloud.
 
 To create a new Shipment on the shipclod platform, you need to provide the name of the carrier, to- and from-address, and the package dimensions.
 For details, see *[shipcloud API documentation on Shipments](http://developers.shipcloud.io/reference/#shipments)*
-```
+```ruby
 Shipcloud::Shipment.create(
     carrier: 'ups',
     from: from-address-params,
@@ -52,7 +67,7 @@ Shipcloud::Shipment.create(
 
 `Shipment#create` will return shipping label and tracking information, encapsulated in a `Shipcloud::Shipment` object:
 
-```
+```ruby
 shipment = Shipcloud::Shipment.create(...) # parameters ommitted
 shipment.tracking_url # -> http://track.shipcloud.io/uzdgu22z3ed12
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Ruby wrapper for the shipcloud API
 
+We have dropped the support of jruby-9, because there is an issue with mixing hash and keyword arguments (https://github.com/jruby/jruby/issues/3138). When this issue is fixed, we will support jruby-9 again.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/shipcloud.rb
+++ b/lib/shipcloud.rb
@@ -12,8 +12,6 @@ module Shipcloud
     "User-Agent" => "shipcloud-ruby v#{Shipcloud::VERSION}, API #{Shipcloud::API_VERSION}, #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
   }
 
-  @@api_key = nil
-
   autoload :Base,           "shipcloud/base"
   autoload :Shipment,       "shipcloud/shipment"
   autoload :Carrier,        "shipcloud/carrier"
@@ -75,7 +73,6 @@ module Shipcloud
   #
   # @param [String] api_key The api key
   def self.api_key=(api_key)
-    @@api_key = api_key
     configuration.api_key = api_key
   end
 
@@ -84,9 +81,12 @@ module Shipcloud
   # @param [Symbol] http_method The http method to use, must be one of :get, :post, :put and :delete
   # @param [String] api_url The API url to use
   # @param [Hash] data The data to send, e.g. used when creating new objects.
+  # @param [String] optional api_key The api key. If no api key is given, Shipcloud.api_key will
+  # be used for the request
   # @return [Array] The parsed JSON response.
-  def self.request(http_method, api_url, data)
-    info = Request::Info.new(http_method, api_url, data)
+  def self.request(http_method, api_url, data, api_key: nil)
+    api_key ||= Shipcloud.api_key
+    info = Request::Info.new(http_method, api_url, api_key, data)
     Request::Base.new(info).perform
   end
 end

--- a/lib/shipcloud/operations/all.rb
+++ b/lib/shipcloud/operations/all.rb
@@ -3,8 +3,12 @@ module Shipcloud
     module All
       module ClassMethods
         # Loads all Objects of the resource
-        def all(filter = {})
-          response = Shipcloud.request(:get, base_url, filter)
+        # @param [Hash] optional filter Filter the shipments list using one or more filter
+        # creteria
+        # @param [String] optional api_key The api key. If no api key is given, Shipcloud.api_key
+        # will be used for the request
+        def all(filter = {}, api_key: nil)
+          response = Shipcloud.request(:get, base_url, filter, api_key: api_key)
           if index_response_root
             response = response.fetch(index_response_root, [])
           end

--- a/lib/shipcloud/operations/create.rb
+++ b/lib/shipcloud/operations/create.rb
@@ -5,8 +5,10 @@ module Shipcloud
         # Creates a new object
         #
         # @param [Hash] attributes The attributes of the created object
-        def create(attributes)
-          response = Shipcloud.request(:post, base_url, attributes)
+        # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+        # will be used for the request
+        def create(attributes, api_key: nil)
+          response = Shipcloud.request(:post, base_url, attributes, api_key: api_key)
           if create_response_root
             response = response.fetch(create_response_root, {})
           end

--- a/lib/shipcloud/operations/delete.rb
+++ b/lib/shipcloud/operations/delete.rb
@@ -5,8 +5,10 @@ module Shipcloud
         # Deletes the given object
         #
         # @param [String] id The id of the object that gets deleted
-        def delete(id)
-          response = Shipcloud.request(:delete, "#{base_url}/#{id}", {})
+        # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+        # will be used for the request
+        def delete(id, api_key: nil)
+          Shipcloud.request(:delete, "#{base_url}/#{id}", {}, api_key: api_key)
           true
         end
       end

--- a/lib/shipcloud/operations/find.rb
+++ b/lib/shipcloud/operations/find.rb
@@ -5,9 +5,11 @@ module Shipcloud
         # Finds a given object
         #
         # @param [String] id The id of the object that should be found
+        # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+        # will be used for the request
         # @return [Shipcloud::Base] The found object
-        def find(id)
-          response = Shipcloud.request(:get, "#{base_url}/#{id}", {})
+        def find(id, api_key: nil)
+          response = Shipcloud.request(:get, "#{base_url}/#{id}", {}, api_key: api_key)
           self.new(response)
         end
       end

--- a/lib/shipcloud/operations/update.rb
+++ b/lib/shipcloud/operations/update.rb
@@ -6,8 +6,10 @@ module Shipcloud
         # Updates a object
         # @param [String] id The id of the object that should be updated
         # @param [Hash] attributes The attributes that should be updated
-        def update(id, attributes)
-          response = Shipcloud.request(:put, "#{base_url}/#{id}", attributes)
+        # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+        # will be used for the request
+        def update(id, attributes, api_key: nil)
+          response = Shipcloud.request(:put, "#{base_url}/#{id}", attributes, api_key: api_key)
           self.new(response)
         end
       end
@@ -19,8 +21,10 @@ module Shipcloud
       # Updates a object
       #
       # @param [Hash] attributes The attributes that should be updated
-      def update(attributes)
-        response = Shipcloud.request(:put, "#{base_url}/#{id}", attributes)
+      # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+      # will be used for the request
+      def update(attributes, api_key: nil)
+        response = Shipcloud.request(:put, "#{base_url}/#{id}", attributes, api_key: api_key)
         set_attributes(response)
       end
     end

--- a/lib/shipcloud/request/base.rb
+++ b/lib/shipcloud/request/base.rb
@@ -9,7 +9,7 @@ module Shipcloud
       end
 
       def perform
-        raise AuthenticationError if Shipcloud.api_key.nil?
+        raise AuthenticationError unless @info.api_key
         connection.setup_https
         send_request
         validator.validated_data_for(response)

--- a/lib/shipcloud/request/connection.rb
+++ b/lib/shipcloud/request/connection.rb
@@ -38,7 +38,7 @@ module Shipcloud
                         else
                           Net::HTTP::Get.new(@info.path_with_params(@info.url, @info.data), API_HEADERS)
                         end
-        https_request.basic_auth(Shipcloud.api_key, "")
+        https_request.basic_auth(@info.api_key, "")
         https_request.body = @info.data.to_json if [:post, :put].include?(@info.http_method)
         https_request
       end

--- a/lib/shipcloud/request/info.rb
+++ b/lib/shipcloud/request/info.rb
@@ -1,9 +1,10 @@
 module Shipcloud
   module Request
     class Info
-      attr_accessor :http_method, :api_url, :data
+      attr_accessor :http_method, :api_url, :api_key, :data
 
-      def initialize(http_method, api_url, data)
+      def initialize(http_method, api_url, api_key, data)
+        @api_key = api_key
         @http_method = http_method
         @api_url     = api_url
         @data        = data

--- a/spec/shipcloud/address_spec.rb
+++ b/spec/shipcloud/address_spec.rb
@@ -35,31 +35,35 @@ describe Shipcloud::Address do
 
   describe '.create' do
     it 'makes a new POST request using the correct API endpoint' do
-      Shipcloud.should_receive(:request).with(:post, 'addresses', valid_attributes).and_return('data' => {})
+      expect(Shipcloud).to receive(:request).
+        with(:post, "addresses", valid_attributes, api_key: nil).and_return("data" => {})
+
       Shipcloud::Address.create(valid_attributes)
     end
   end
 
   describe '.find' do
     it 'makes a new GET request using the correct API endpoint to receive a specific address' do
-      Shipcloud.should_receive(:request).with(
-        :get, 'addresses/123', {}).and_return('id' => '123')
-      Shipcloud::Address.find('123')
+      expect(Shipcloud).to receive(:request).with(
+        :get, "addresses/123", {}, api_key: nil).and_return("id" => "123")
+
+      Shipcloud::Address.find("123")
     end
   end
 
   describe '.update' do
     it 'makes a new PUT request using the correct API endpoint' do
-      Shipcloud.should_receive(:request).with(
-        :put, 'addresses/123', {:street => 'Mittelweg' }).and_return('data' => {})
-      Shipcloud::Address.update('123', {:street => 'Mittelweg' })
+      expect(Shipcloud).to receive(:request).with(
+        :put, "addresses/123", { street: "Mittelweg" }, api_key: nil).and_return("data" => {})
+
+      Shipcloud::Address.update("123", street: "Mittelweg")
     end
   end
 
   describe '.all' do
     it 'makes a new Get request using the correct API endpoint' do
       expect(Shipcloud).to receive(:request).
-        with(:get, 'addresses', {}).and_return([])
+        with(:get, "addresses", {}, api_key: nil).and_return([])
 
       Shipcloud::Address.all
     end
@@ -77,38 +81,38 @@ describe Shipcloud::Address do
 
   def stub_addresses_request
     allow(Shipcloud).to receive(:request).
-      with(:get, 'addresses', {}).
-        and_return(
-          [
-            {
-              'id' => '1c81efb7-9b95-4dd8-92e3-cac1bca3df6f',
-              'company' => '',
-              'first_name' => 'Max',
-              'last_name' => 'Mustermann',
-              'care_of' => '',
-              'street' => 'Musterstraße',
-              'street_no' => '42',
-              'zip_code' => '12345',
-              'city' => 'Musterstadt',
-              'state' => '',
-              'country' => 'DE',
-              'phone' => ''
-            },
-            {
-              'id' => '7ea2a290-b456-4ecf-9010-e82b3da298f0',
-              'company' => 'Muster-Company',
-              'first_name' => 'Max',
-              'last_name' => 'Mustermann',
-              'care_of' => '',
-              'street' => 'Musterstraße',
-              'street_no' => '42',
-              'zip_code' => '54321',
-              'city' => 'Musterstadt',
-              'state' => '',
-              'country' => 'DE',
-              'phone' => ''
-            }
-          ]
-        )
+      with(:get, "addresses", {}, api_key: nil).
+      and_return(
+        [
+          {
+            "id" => "1c81efb7-9b95-4dd8-92e3-cac1bca3df6f",
+            "company" => "",
+            "first_name" => "Max",
+            "last_name" => "Mustermann",
+            "care_of" => "",
+            "street" => "Musterstraße",
+            "street_no" => "42",
+            "zip_code" => "12345",
+            "city" => "Musterstadt",
+            "state" => "",
+            "country" => "DE",
+            "phone" => ""
+          },
+          {
+            "id" => "7ea2a290-b456-4ecf-9010-e82b3da298f0",
+            "company" => "Muster-Company",
+            "first_name" => "Max",
+            "last_name" => "Mustermann",
+            "care_of" => "",
+            "street" => "Musterstraße",
+            "street_no" => "42",
+            "zip_code" => "54321",
+            "city" => "Musterstadt",
+            "state" => "",
+            "country" => "DE",
+            "phone" => ""
+          }
+        ]
+      )
   end
 end

--- a/spec/shipcloud/carrier_spec.rb
+++ b/spec/shipcloud/carrier_spec.rb
@@ -24,7 +24,7 @@ describe Shipcloud::Carrier do
   describe '.all' do
     it 'makes a new Get request using the correct API endpoint' do
       expect(Shipcloud).to receive(:request).
-        with(:get, 'carriers', {}).and_return([])
+        with(:get, "carriers", {}, api_key: nil).and_return([])
 
       Shipcloud::Carrier.all
     end
@@ -69,9 +69,9 @@ describe Shipcloud::Carrier do
   end
 
   def stub_carriers_request
-    allow(Shipcloud).to receive(:request)
-      .with(:get, 'carriers', {})
-      .and_return(
+    allow(Shipcloud).to receive(:request).
+      with(:get, "carriers", {}, api_key: nil).
+      and_return(
         [
           {
             'name' => 'carrier_1',

--- a/spec/shipcloud/request/base_spec.rb
+++ b/spec/shipcloud/request/base_spec.rb
@@ -3,25 +3,26 @@ require "spec_helper"
 describe Shipcloud::Request::Base do
   context "#perform" do
     it "checks for an api key" do
-      Shipcloud.stub(:api_key).and_return(nil)
+      info = Shipcloud::Request::Info.new(:get, "shipments", nil, {})
 
       expect{
-        Shipcloud::Request::Base.new(nil).perform
+        Shipcloud::Request::Base.new(info).perform
       }.to raise_error Shipcloud::AuthenticationError
     end
 
     it "performs an https request" do
-      Shipcloud.stub(:api_key).and_return("some key")
-      connection = stub
-      validator = stub
-      Shipcloud::Request::Connection.stub(:new).and_return(connection)
-      Shipcloud::Request::Validator.stub(:new).and_return(validator)
+      info = Shipcloud::Request::Info.new(:get, "shipments", "api_key", {})
+      connection = double
+      validator = double
+      allow(Shipcloud::Request::Connection).to receive(:new).with(info).and_return(connection)
+      allow(Shipcloud::Request::Validator).to receive(:new).with(info).and_return(validator)
 
-      connection.should_receive(:setup_https)
-      connection.should_receive(:request)
-      validator.should_receive(:validated_data_for)
+      expect(connection).to receive(:setup_https)
+      response = double
+      expect(connection).to receive(:request).and_return(response)
+      expect(validator).to receive(:validated_data_for).with(response)
 
-      Shipcloud::Request::Base.new(nil).perform
+      Shipcloud::Request::Base.new(info).perform
     end
   end
 end

--- a/spec/shipcloud/request/validator_spec.rb
+++ b/spec/shipcloud/request/validator_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Shipcloud::Request::Validator do
   describe "#validated_data_for" do
     it "validates the data" do
-      info = Shipcloud::Request::Info.new(:get, "random", OpenStruct.new(id: 1))
+      info = Shipcloud::Request::Info.new(:get, "random", "api_key", id: 1)
       validator = Shipcloud::Request::Validator.new info
       response = OpenStruct.new(body: '{"response":"ok"}', code: 200)
 
@@ -11,7 +11,7 @@ describe Shipcloud::Request::Validator do
     end
 
     it 'raises an APIError if the response contains errors' do
-      info = Shipcloud::Request::Info.new(:get, 'random', {})
+      info = Shipcloud::Request::Info.new(:get, "random", "api_key", {})
       validator = Shipcloud::Request::Validator.new info
       response = OpenStruct.new(body: '{"errors":["some error"]}', code: 200)
 

--- a/spec/shipcloud/shipment_quote_spec.rb
+++ b/spec/shipcloud/shipment_quote_spec.rb
@@ -52,7 +52,7 @@ describe Shipcloud::ShipmentQuote do
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).
-        with(:post, "shipment_quotes", valid_attributes).
+        with(:post, "shipment_quotes", valid_attributes, api_key: nil).
         and_return("data" => {})
 
       Shipcloud::ShipmentQuote.create(valid_attributes)

--- a/spec/shipcloud/shipment_spec.rb
+++ b/spec/shipcloud/shipment_spec.rb
@@ -47,28 +47,32 @@ describe Shipcloud::Shipment do
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Shipcloud.should_receive(:request).with(:post, "shipments", valid_attributes).and_return("data" => {})
+      expect(Shipcloud).to receive(:request).
+        with(:post, "shipments", valid_attributes, api_key: nil).and_return("data" => {})
       Shipcloud::Shipment.create(valid_attributes)
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific subscription" do
-      Shipcloud.should_receive(:request).with(:get, "shipments/123", {}).and_return("id" => "123")
+      expect(Shipcloud).to receive(:request).with(:get, "shipments/123", {}, api_key: nil).
+        and_return("id" => "123")
       Shipcloud::Shipment.find("123")
     end
   end
 
   describe ".update" do
     it "makes a new PUT request using the correct API endpoint" do
-      Shipcloud.should_receive(:request).with(:put, "shipments/123", {:carrier => 'ups' }).and_return("data" => {})
-      Shipcloud::Shipment.update("123", {:carrier => 'ups' })
+      expect(Shipcloud).to receive(:request).
+        with(:put, "shipments/123", { carrier: "ups" }, api_key: nil).and_return("data" => {})
+      Shipcloud::Shipment.update("123", carrier: "ups")
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Shipcloud.should_receive(:request).with(:delete, "shipments/123", {}).and_return(true)
+      expect(Shipcloud).to receive(:request).with(:delete, "shipments/123", {}, api_key: nil).
+        and_return(true)
       Shipcloud::Shipment.delete("123")
     end
   end
@@ -76,7 +80,7 @@ describe Shipcloud::Shipment do
   describe ".all" do
     it "makes a new Get request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).
-        with(:get, "shipments", {}).
+        with(:get, "shipments", {}, api_key: nil).
         and_return("shipments" => [])
 
       Shipcloud::Shipment.all
@@ -104,7 +108,7 @@ describe Shipcloud::Shipment do
       }
 
       expect(Shipcloud).to receive(:request).
-        with(:get, "shipments", filter).
+        with(:get, "shipments", filter, api_key: nil).
         and_return("shipments" => shipments_array)
 
       Shipcloud::Shipment.all(filter)
@@ -113,7 +117,7 @@ describe Shipcloud::Shipment do
 
   def stub_shipments_requests
     allow(Shipcloud).to receive(:request).
-      with(:get, "shipments", {}).
+      with(:get, "shipments", {}, api_key: nil).
       and_return("shipments" => shipments_array)
   end
 

--- a/spec/shipcloud/webhooks_spec.rb
+++ b/spec/shipcloud/webhooks_spec.rb
@@ -16,8 +16,8 @@ describe Shipcloud::Webhook do
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Shipcloud.should_receive(:request).
-        with(:post, "webhooks", valid_attributes).
+      expect(Shipcloud).to receive(:request).
+        with(:post, "webhooks", valid_attributes, api_key: nil).
         and_return("data" => {})
       Shipcloud::Webhook.create(valid_attributes)
     end
@@ -25,7 +25,9 @@ describe Shipcloud::Webhook do
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific webhook" do
-      Shipcloud.should_receive(:request).with(:get, "webhooks/123", {}).and_return("id" => "123")
+      expect(Shipcloud).to receive(:request).
+        with(:get, "webhooks/123", {}, api_key: nil).
+        and_return("id" => "123")
       Shipcloud::Webhook.find("123")
     end
   end
@@ -33,7 +35,7 @@ describe Shipcloud::Webhook do
   describe ".all" do
     it "makes a new Get request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).
-        with(:get, "webhooks", {}).
+        with(:get, "webhooks", {}, api_key: nil).
         and_return("webhooks" => [])
 
       Shipcloud::Webhook.all
@@ -52,7 +54,7 @@ describe Shipcloud::Webhook do
 
   def stub_webhooks_request
     allow(Shipcloud).to receive(:request).
-      with(:get, "webhooks", {}).
+      with(:get, "webhooks", {}, api_key: nil).
       and_return("webhooks" => webhooks_array)
   end
 

--- a/spec/shipcloud_spec.rb
+++ b/spec/shipcloud_spec.rb
@@ -29,6 +29,20 @@ describe Shipcloud do
         WebMock.should have_requested(:get, "https://#{Shipcloud::api_key}:@#{Shipcloud.configuration.api_base}/#{Shipcloud::API_VERSION}/transactions")
       end
     end
+
+    context "with an api key passed in as an argument" do
+      it "uses the given api key instead of the global one" do
+        WebMock.stub_request(:any, /#{Shipcloud.configuration.api_base}/).to_return(body: "{}")
+        Shipcloud.api_key = "global-api-key"
+
+        Shipcloud.request(:get, "transactions", {}, api_key: "123")
+
+        expect(WebMock).to have_requested(
+          :get,
+          "https://123:@#{Shipcloud.configuration.api_base}/#{Shipcloud::API_VERSION}/transactions"
+        )
+      end
+    end
   end
 
   describe '.configure' do


### PR DESCRIPTION
on every request.

With this one can use different api keys (e.g sandbox, live) in parallel.
