### PR TITLE
drop ruby 1.9.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.5
   - 2.2.1
-  - jruby
+  - 2.2.2
+  - 2.2.3
+  - jruby-9.0.0.0
   - rbx-2
 notifications:
   flowdock:

--- a/shipcloud.gemspec
+++ b/shipcloud.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.0"
+
   spec.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.0'
   spec.add_development_dependency 'bundler', '>= 1.3.0', '< 2.0'
   spec.add_development_dependency 'rake', '~> 10.3'


### PR DESCRIPTION
in order to use the new language features of ruby 2.0

The official support of ruby 1.9.3 already ended on February 23, 2015
https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/
