### PR TITLE
Parse response only when it's not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 ### Fixed
+- Parse response only when it is not empty
 
 ## [0.7.0] - 2016-01-21
 ### Added

--- a/lib/shipcloud/request/base.rb
+++ b/lib/shipcloud/request/base.rb
@@ -12,7 +12,7 @@ module Shipcloud
         connection.setup_https
         response = connection.request
         validate_response(response)
-        JSON.parse(response.body)
+        JSON.parse(response.body) unless response.body.nil?
       rescue JSON::ParserError
         raise ShipcloudError.new(response)
       end


### PR DESCRIPTION
Previously, 

``` ruby
Shipcloud::Shipment.delete <id>
```

caused TypeError converting nil to String
