### PR TITLE
Add affiliate_id to Shipcloud::Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add resource pickup_request in order to submit pickup request to shipcloud
 - Add attribute ```pickup_address``` to class ```Shipcloud::PickupRequest``` to submit an alternative address for pickup request to shipcloud
 - Add attribute ```deactivated``` to class ```Shipcloud::Webhook```
+- Add optional ```affiliate_id``` to ```Shipcloud::Configuration``` and submit it via API headers to shipcloud
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add resource pickup_request in order to submit pickup request to shipcloud
 - Add attribute ```pickup_address``` to class ```Shipcloud::PickupRequest``` to submit an alternative address for pickup request to shipcloud
 - Add attribute ```deactivated``` to class ```Shipcloud::Webhook```
-- Add optional ```affiliate_id``` to ```Shipcloud::Configuration``` and submit it via API headers to shipcloud
+- Add ```affiliate_id``` to ```Shipcloud::Configuration``` and submit it (or a default affiliate id) via API headers to shipcloud
 
 ### Removed
 

--- a/lib/shipcloud.rb
+++ b/lib/shipcloud.rb
@@ -13,6 +13,8 @@ module Shipcloud
     "User-Agent" => "shipcloud-ruby v#{Shipcloud::VERSION}, API #{Shipcloud::API_VERSION}, #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
   }
 
+  DEFAULT_AFFILIATE_ID = "integration.shipcloud-ruby-gem.v#{Shipcloud::VERSION}".freeze
+
   autoload :Base,           "shipcloud/base"
   autoload :Shipment,       "shipcloud/shipment"
   autoload :Carrier,        "shipcloud/carrier"
@@ -49,7 +51,7 @@ module Shipcloud
 
   def self.api_headers
     API_HEADERS.merge(
-      "Affiliate-ID" => configuration.affiliate_id
+      "Affiliate-ID" => configuration.affiliate_id || DEFAULT_AFFILIATE_ID
     ).reject { |_k, v| v.nil? }
   end
 

--- a/lib/shipcloud.rb
+++ b/lib/shipcloud.rb
@@ -52,7 +52,7 @@ module Shipcloud
   def self.api_headers
     API_HEADERS.merge(
       "Affiliate-ID" => configuration.affiliate_id || DEFAULT_AFFILIATE_ID
-    ).reject { |_k, v| v.nil? }
+    )
   end
 
   class Configuration

--- a/lib/shipcloud.rb
+++ b/lib/shipcloud.rb
@@ -47,9 +47,14 @@ module Shipcloud
     yield(configuration)
   end
 
+  def self.api_headers
+    API_HEADERS.merge(
+      "Affiliate-ID" => configuration.affiliate_id
+    ).reject { |_k, v| v.nil? }
+  end
 
   class Configuration
-    attr_accessor :api_key, :api_base, :use_ssl, :debug
+    attr_accessor :affiliate_id, :api_key, :api_base, :use_ssl, :debug
 
     def initialize
       @api_key = nil

--- a/lib/shipcloud/request/connection.rb
+++ b/lib/shipcloud/request/connection.rb
@@ -28,16 +28,21 @@ module Shipcloud
       protected
 
       def https_request
-        https_request = case @info.http_method
-                        when :post
-                          Net::HTTP::Post.new(@info.url, API_HEADERS)
-                        when :put
-                          Net::HTTP::Put.new(@info.url, API_HEADERS)
-                        when :delete
-                          Net::HTTP::Delete.new(@info.url, API_HEADERS)
-                        else
-                          Net::HTTP::Get.new(@info.path_with_params(@info.url, @info.data), API_HEADERS)
-                        end
+        https_request =
+          case @info.http_method
+          when :post
+            Net::HTTP::Post.new(@info.url, Shipcloud.api_headers)
+          when :put
+            Net::HTTP::Put.new(@info.url, Shipcloud.api_headers)
+          when :delete
+            Net::HTTP::Delete.new(@info.url, Shipcloud.api_headers)
+          else
+            Net::HTTP::Get.new(
+              @info.path_with_params(@info.url, @info.data),
+              Shipcloud.api_headers,
+            )
+          end
+
         https_request.basic_auth(@info.api_key, "")
         https_request.body = @info.data.to_json if [:post, :put].include?(@info.http_method)
         https_request

--- a/spec/shipcloud/request/info_spec.rb
+++ b/spec/shipcloud/request/info_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::Request::Info do

--- a/spec/shipcloud/request/info_spec.rb
+++ b/spec/shipcloud/request/info_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe Shipcloud::Request::Info do
+  describe "#url" do
+    it "returns the correct url" do
+      info = Shipcloud::Request::Info.new(:get, "shipments", "api_key", {})
+
+      expect(info.url).to eq "/v1/shipments"
+    end
+  end
+
+  describe "#path_with_params" do
+    it "returns just the path if there aren't any params" do
+      info = Shipcloud::Request::Info.new(:get, "shipments", "api_key", {})
+      path = info.path_with_params(info.url, info.data)
+
+      expect(path).to eq "/v1/shipments"
+    end
+
+    it "returns the path and given params" do
+      info = Shipcloud::Request::Info.new(:get, "shipments", "api_key", foo: "bar")
+      path = info.path_with_params(info.url, info.data)
+
+      expect(path).to eq "/v1/shipments?foo=bar"
+    end
+  end
+end

--- a/spec/shipcloud_spec.rb
+++ b/spec/shipcloud_spec.rb
@@ -99,5 +99,42 @@ describe Shipcloud do
       end
       expect(Shipcloud.configuration.debug).to be true
     end
+
+    it "defaults affiliate_id to nil" do
+      expect(Shipcloud.configuration.affiliate_id).to be_nil
+    end
+
+    it "sets and gets the affiliate_id" do
+      Shipcloud.configure do |config|
+        config.affiliate_id = "integration.my_rails_app.1234567"
+      end
+
+      expect(Shipcloud.configuration.affiliate_id).to eq "integration.my_rails_app.1234567"
+    end
+  end
+
+  describe ".api_headers" do
+    it "returns the correct api headers" do
+      Shipcloud.configuration = nil # reset configuration
+
+      expect(Shipcloud.api_headers).to eq(
+        "Content-Type" => "application/json",
+        "User-Agent" => "shipcloud-ruby v#{Shipcloud::VERSION}, API #{Shipcloud::API_VERSION}, " \
+          "#{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}",
+      )
+    end
+
+    it "returns the correct api headers with affiliate id if configured" do
+      Shipcloud.configure do |config|
+        config.affiliate_id = "integration.my_rails_app.1234567"
+      end
+
+      expect(Shipcloud.api_headers).to eq(
+        "Content-Type" => "application/json",
+        "User-Agent" => "shipcloud-ruby v#{Shipcloud::VERSION}, API #{Shipcloud::API_VERSION}, " \
+          "#{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}",
+        "Affiliate-ID" => "integration.my_rails_app.1234567",
+      )
+    end
   end
 end

--- a/spec/shipcloud_spec.rb
+++ b/spec/shipcloud_spec.rb
@@ -114,13 +114,14 @@ describe Shipcloud do
   end
 
   describe ".api_headers" do
-    it "returns the correct api headers" do
+    it "returns the correct api headers with default affiliate id" do
       Shipcloud.configuration = nil # reset configuration
 
       expect(Shipcloud.api_headers).to eq(
         "Content-Type" => "application/json",
         "User-Agent" => "shipcloud-ruby v#{Shipcloud::VERSION}, API #{Shipcloud::API_VERSION}, " \
           "#{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}",
+        "Affiliate-ID" => "integration.shipcloud-ruby-gem.v#{Shipcloud::VERSION}",
       )
     end
 


### PR DESCRIPTION
The ```affiliate_id``` can be set via ```Shipcloud::Configuration```.

If set the value will be submitted via API headers to shipcloud.

If no affiliate id is set a default value will be used.

The class ```Shipcloud::Request::Connection``` will use the method
```Shipcloud.api_headers``` instead of the constant ```API_HEADERS```
from now on.

Moreover a spec file for the class ```Shipcloud::Request::Info```
has been added.