### PR TITLE
addresses now return their ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### Added
+- Add attr_reader for `id` to class `Shipcloud::Address` to be able to get the id of a created address
 
 ### Changed
 

--- a/lib/shipcloud/address.rb
+++ b/lib/shipcloud/address.rb
@@ -5,6 +5,7 @@ module Shipcloud
 
     attr_accessor :company, :first_name, :last_name, :care_of, :street,
                   :street_no, :zip_code, :city, :state, :country, :phone
+    attr_reader :id
 
     def self.base_url
       "#{class_name.downcase}es"

--- a/spec/shipcloud/address_spec.rb
+++ b/spec/shipcloud/address_spec.rb
@@ -40,6 +40,16 @@ describe Shipcloud::Address do
 
       Shipcloud::Address.create(valid_attributes)
     end
+
+    it "returns an address containing an id" do
+      expect(Shipcloud).to receive(:request).
+        with(:post, "addresses", valid_attributes, api_key: nil).
+        and_return(returned_address)
+
+      address = Shipcloud::Address.create(valid_attributes)
+
+      expect(address.id).to eq("1c81efb7-9b95-4dd8-92e3-cac1bca3df6f")
+    end
   end
 
   describe '.find' do
@@ -114,5 +124,22 @@ describe Shipcloud::Address do
           }
         ]
       )
+  end
+
+  def returned_address
+    {
+      "id" => "1c81efb7-9b95-4dd8-92e3-cac1bca3df6f",
+      "company" => "shipcloud GmbH",
+      "first_name" => "Maxi",
+      "last_name" => "Musterfrau",
+      "care_of" => "Mustermann",
+      "street" => "Musterstraße",
+      "street_no" => "123",
+      "zip_code" => "12345",
+      "city" => "Hamburg",
+      "state" => "Hamburg",
+      "country" => "DE",
+      "phone" => "040/123456789",
+    }
   end
 end


### PR DESCRIPTION
This makes it possible to use the id of an address e.g. for creating a shipment without having to supply to complete set of address data