### PR TITLE
Make id attribute of Shipcloud::Webhook accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 ### Added
 - Add attr_reader for `id` to class `Shipcloud::Address` to be able to get the id of a created address
-- Add attr_reader for `id` to class `Shipcloud::Webhook` to be able to get the id of a created webhook
+- Add attr_reader for `id` to class `Shipcloud::Webhook` to be able to get the id of the created webhook
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - Add attr_reader for `id` to class `Shipcloud::Address` to be able to get the id of a created address
+- Add attr_reader for `id` to class `Shipcloud::Webhook` to be able to get the id of a created webhook
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 ### Added
 - Add attr_reader for `id` to class `Shipcloud::Address` to be able to get the id of a created address
-- Add attr_reader for `id` to class `Shipcloud::Webhook` to be able to get the id of the created webhook
+- Add attr_reader for `id` to class `Shipcloud::Webhook` to be able to get the id of a created webhook
 
 ### Changed
 

--- a/lib/shipcloud/webhook.rb
+++ b/lib/shipcloud/webhook.rb
@@ -3,7 +3,7 @@ module Shipcloud
     include Shipcloud::Operations::All
     include Shipcloud::Operations::Delete
 
-    attr_reader :url, :event_types, :deactivated
+    attr_reader :id, :url, :event_types, :deactivated
 
     def self.index_response_root
       "webhooks"

--- a/spec/shipcloud/webhooks_spec.rb
+++ b/spec/shipcloud/webhooks_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Shipcloud::Webhook do
   valid_attributes = {
-    id: "583cfd8b-77c7-4447-a3a0-1568bb9cc553", 
+    id: "583cfd8b-77c7-4447-a3a0-1568bb9cc553",
     url: "https://example.com/webhook",
     event_types: ["shipment.tracking.delayed", "shipment.tracking.delivered"]
   }

--- a/spec/shipcloud/webhooks_spec.rb
+++ b/spec/shipcloud/webhooks_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe Shipcloud::Webhook do
   valid_attributes = {
+    id: "583cfd8b-77c7-4447-a3a0-1568bb9cc553", 
     url: "https://example.com/webhook",
     event_types: ["shipment.tracking.delayed", "shipment.tracking.delivered"]
   }
@@ -11,6 +12,7 @@ describe Shipcloud::Webhook do
       webhook = Shipcloud::Webhook.new(valid_attributes)
       expect(webhook.url).to eq "https://example.com/webhook"
       expect(webhook.event_types).to eq ["shipment.tracking.delayed", "shipment.tracking.delivered"]
+      expect(webhook.id).to eq "583cfd8b-77c7-4447-a3a0-1568bb9cc553"
     end
   end
 


### PR DESCRIPTION
In order to delete a formerly registered webhook a client app must be able to store the webhook id. Currently this is only possible by reaching into the Webhook Object via `instance_variable_get(:@id)`.

By making the `id` available via attr_reader this mess can be replaced by a simple `webhook.id` call.