### PR TITLE
Support shipments with pickup requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 ### Added
 
+- Support shipments with pickup requests as required for [TNT](https://developers.shipcloud.io/carriers/tnt.html).
+
 ### Changed
 
 ### Deprecated

--- a/lib/shipcloud/shipment.rb
+++ b/lib/shipcloud/shipment.rb
@@ -6,7 +6,7 @@ module Shipcloud
 
     attr_accessor :from, :to, :carrier, :package, :reference_number, :metadata
     attr_reader :id, :created_at, :carrier_tracking_no, :tracking_url, :label_url,
-                :packages, :price, :customs_declaration
+                :packages, :price, :customs_declaration, :pickup
 
     def self.index_response_root
       "#{class_name.downcase}s"

--- a/spec/shipcloud/shipment_spec.rb
+++ b/spec/shipcloud/shipment_spec.rb
@@ -32,6 +32,12 @@ describe Shipcloud::Shipment do
         id: "123456",
         contents_type: "commercial_goods",
       },
+      pickup: {
+        pickup_time: {
+          earliest: "2020-07-24T13:59:58+23:57",
+          latest: "2020-07-24T18:59:58+23:57",
+        }
+      }
     }
   end
 
@@ -58,6 +64,8 @@ describe Shipcloud::Shipment do
 
       expect(shipment.customs_declaration[:id]).to eq "123456"
       expect(shipment.customs_declaration[:contents_type]).to eq "commercial_goods"
+      expect(shipment.pickup[:pickup_time][:earliest]).to eq "2020-07-24T13:59:58+23:57"
+      expect(shipment.pickup[:pickup_time][:latest]).to eq "2020-07-24T18:59:58+23:57"
     end
 
     it "initializes the metadata correctly" do


### PR DESCRIPTION
Express carriers like
[TNT](https://developers.shipcloud.io/carriers/tnt.html) need the pickup
time frame creating the shipment. This change is compatible for
non-express carriers.