### PR TITLE
Update rubocop and rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,239 @@
 require: rubocop-performance
 
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.6
   Exclude:
     - vendor/**/*
     - bin/*
+
+# rubocop
+# https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml
+
+# Layout - https://docs.rubocop.org/rubocop/cops_layout.html
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
+  Enabled: false
+
+Layout/DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
+  EnforcedStyle: trailing
+
+Layout/EmptyLineAfterMagicComment:
+  Description: 'Add an empty line after magic comments to separate them from code.'
+  StyleGuide: '#separate-magic-comments-from-code'
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Description: "Keep blank lines around attribute accessors."
+  Enabled: true
+
+Layout/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
+  Enabled: true
+
+Layout/FirstArrayElementLineBreak:
+  Description: >-
+                 Checks for a line break before the first element in a
+                 multi-line array.
+  Enabled: true
+
+Layout/FirstHashElementLineBreak:
+  Description: >-
+                 Checks for a line break before the first element in a
+                 multi-line hash.
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Description: >-
+                 Checks for a line break before the first argument in a
+                 multi-line method call.
+  Enabled: true
+
+Layout/InitialIndentation:
+  Description: >-
+    Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: false
+
+Layout/LineLength:
+  Description: "Limit lines to 100 characters."
+  Max: 100
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  Description: >-
+                 Checks indentation of method calls with the dot operator
+                 that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  Description: >-
+                 Checks indentation of binary operations that span more than
+                 one line.
+  Enabled: true
+  EnforcedStyle: indented
+
+# Lint - https://docs.rubocop.org/rubocop/cops_lint.html
+
+Lint/AmbiguousOperator:
+  Description: >-
+                 Checks for ambiguous operators in the first argument of a
+                 method invocation without parentheses.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
+  Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+  Description: >-
+                 Checks for ambiguous regexp literals in the first argument of
+                 a method invocation without parenthesis.
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Description: "Don't use assignment in conditions."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
+  Enabled: false
+
+Lint/DeprecatedClassMethods:
+  Description: 'Check for deprecated class method calls.'
+  Enabled: false
+
+Lint/DuplicateHashKey:
+  Description: 'Check for duplicate keys in hash literals.'
+  Enabled: false
+
+Lint/EachWithObjectArgument:
+  Description: 'Check for immutable argument given to each_with_object.'
+  Enabled: false
+
+Lint/ElseLayout:
+  Description: 'Check for odd code arrangement in an else block.'
+  Enabled: false
+
+Lint/FlipFlop:
+  Description: 'Checks for flip flops'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
+  Enabled: false
+
+Lint/FormatParameterMismatch:
+  Description: 'The number of parameters to format/sprint must match the fields.'
+  Enabled: false
+
+Lint/LiteralAsCondition:
+  Description: 'Checks of literals used in conditions.'
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Description: 'Checks for literals used in interpolation.'
+  Enabled: false
+
+Lint/Loop:
+  Description: >-
+                 Use Kernel#loop with break rather than begin/end/until or
+                 begin/end/while for post-loop tests.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Description: 'Do not use nested method definitions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
+  Enabled: false
+
+Lint/NonDeterministicRequireOrder:
+  Description: 'Always sort arrays returned by Dir.glob when requiring files.'
+  Enabled: true
+
+Lint/NonLocalExitFromIterator:
+  Description: 'Do not use return in iterator to cause non-local exit.'
+  Enabled: false
+
+Lint/ParenthesesAsGroupedExpression:
+  Description: >-
+                 Checks for method calls with a space before the opening
+                 parenthesis.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: false
+
+Lint/RaiseException:
+  Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
+  Enabled: true
+
+Lint/RedundantCopDisableDirective:
+  Description: >-
+    Checks for rubocop:disable comments that can be removed.
+    Note: this cop is not disabled when disabling all cops.
+    It must be explicitly disabled.
+    Enabled: false
+
+Lint/RequireParentheses:
+  Description: >-
+                 Use parentheses in the method call to avoid confusion
+                 about precedence.
+  Enabled: false
+
+Lint/SuppressedException:
+  Description: "Don't suppress exception."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Description: 'Do not use prefix `_` for a variable that is used.'
+  Enabled: false
+
+Lint/Void:
+  Description: 'Possible use of operator/literal/variable in void context.'
+  Enabled: false
+
+# Metrics - https://docs.rubocop.org/rubocop/cops_metrics.html
+
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Enabled: false
+
+Metrics/BlockLength:
+  Description: 'Avoid long blocks with many lines.'
+  Enabled: true
+  Exclude:
+    - !ruby/regexp /spec(\/.*)*\/.*\.rb$/
+    - !ruby/regexp /config/routes.rb$/
+
+Metrics/BlockNesting:
+  Description: 'Avoid excessive block nesting'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
+  Enabled: false
+
+Metrics/ClassLength:
+  Description: 'Avoid classes longer than 100 lines of code.'
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Description: >-
+                 A complexity metric that is strongly correlated to the number
+                 of test cases needed to validate a method.
+  Enabled: false
+
+Metrics/MethodLength:
+  Description: 'Avoid methods longer than 10 lines of code.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
+  Enabled: false
+
+Metrics/ModuleLength:
+  Description: 'Avoid modules longer than 100 lines of code.'
+  Enabled: false
+
+Metrics/ParameterLists:
+  Description: 'Avoid parameter lists longer than three or four parameters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
+  Enabled: false
+
+# Naming - https://docs.rubocop.org/rubocop/cops_naming.html
 
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
@@ -15,14 +244,14 @@ Naming/AsciiIdentifiers:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: false
 
-Naming/FileName:
-  Description: 'Use snake_case for source file names.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
-  Enabled: false
-
 Naming/BinaryOperatorParameterName:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
+  Enabled: false
+
+Naming/FileName:
+  Description: 'Use snake_case for source file names.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: false
 
 Naming/MemoizedInstanceVariableName:
@@ -37,20 +266,32 @@ Naming/PredicateName:
     - is_
     - has_
     - have_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
   Exclude:
-    - spec/**/*
+    - !ruby/regexp /spec(\/.*)*\/.*\.rb$/
 
 Naming/RescuedExceptionsVariableName:
   Description: 'Use consistent rescued exceptions variables naming.'
   Enabled: true
   PreferredName: error
 
+# Style - https://docs.rubocop.org/rubocop/cops_style.html
+
+Style/AccessorGrouping:
+  Description: 'Checks for grouping of accessors in `class` and `module` bodies.'
+  Enabled: true
+
 Style/Alias:
   Description: 'Use alias_method instead of alias.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
   Enabled: false
+
+Style/ArrayCoercion:
+  Description: >-
+    Use Array() instead of explicit Array check or [*var], when dealing
+    with a variable you want to treat as an Array, but you're not certain it's an array.
+  Enabled: true
 
 Style/ArrayJoin:
   Description: 'Use Array#join instead of Array#*.'
@@ -71,6 +312,10 @@ Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
   Enabled: false
+
+Style/CaseLikeIf:
+  Description: 'This cop identifies places where `if-elsif` constructions can be replaced with `case-when`.'
+  Enabled: true
 
 Style/CharacterLiteral:
   Description: 'Checks for uses of character literals.'
@@ -107,11 +352,6 @@ Style/CommentAnnotation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
   Enabled: false
 
-Style/PreferredHashMethods:
-  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
-  Enabled: false
-
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
@@ -141,11 +381,6 @@ Style/EvenOdd:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: false
 
-Lint/FlipFlop:
-  Description: 'Checks for flip flops'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
-  Enabled: false
-
 Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
@@ -162,6 +397,30 @@ Style/GuardClause:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: false
 
+Style/HashAsLastArrayItem:
+  Description: >-
+                 Checks for presence or absence of braces around hash literal as a last
+                 array item depending on configuration.
+  Enabled: true
+
+Style/HashEachMethods:
+  Description: 'Use Hash#each_key and Hash#each_value.'
+  Enabled: false
+
+Style/HashLikeCase:
+  Description: >-
+                  Checks for places where `case-when` represents a simple 1:1
+                  mapping and can be replaced with a hash lookup.
+  Enabled: true
+
+Style/HashTransformKeys:
+  Description: 'Prefer `transform_keys` over `each_with_object` and `map`.'
+  Enabled: false
+
+Style/HashTransformValues:
+  Description: 'Prefer `transform_values` over `each_with_object` and `map`.'
+  Enabled: false
+
 Style/IfUnlessModifier:
   Description: >-
                  Favor modifier if/unless usage when you have a
@@ -174,13 +433,11 @@ Style/IfWithSemicolon:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: false
 
-Style/InlineComment:
-  Description: 'Avoid inline comments.'
-  Enabled: false
-
 Style/IpAddresses:
   Description: "Don't include literal IP addresses in code."
   Enabled: true
+  Exclude:
+    - !ruby/regexp /spec(\/.*)*\/.*\.rb$/
 
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
@@ -249,6 +506,16 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
+Style/OptionHash:
+  Description: Don\'t use option hashes when you can use keyword arguments.
+  SuspiciousParamNames:
+    - options
+    - opts
+    - args
+    - params
+    - parameters
+  Enabled: true
+
 Style/PercentLiteralDelimiters:
   Description: 'Use `%`-literal delimiters consistently'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
@@ -257,6 +524,11 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   Description: 'Avoid Perl-style regex back references.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
   Enabled: false
 
 Style/Proc:
@@ -268,6 +540,12 @@ Style/RaiseArgs:
   Description: 'Checks the arguments passed to raise/fail.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#exception-class-messages'
   Enabled: false
+
+Style/RedundantFetchBlock:
+  Description: >-
+                  Use `fetch(key, value)` instead of `fetch(key) { value }`
+                  when value has Numeric, Rational, Complex, Symbol or String type, `false`, `true`, `nil` or is a constant.
+  Enabled: true
 
 Style/RegexpLiteral:
   Description: 'Use / or %r around regular expressions.'
@@ -288,6 +566,11 @@ Style/SelfAssignment:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#self-assignment'
   Enabled: false
 
+Style/SignalException:
+  Description: 'Checks for proper usage of fail and raise.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
+  Enabled: false
+
 Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#reduce-blocks'
@@ -298,10 +581,9 @@ Style/SingleLineMethods:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
   Enabled: false
 
-Style/SignalException:
-  Description: 'Checks for proper usage of fail and raise.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
-  Enabled: false
+Style/SlicingWithRange:
+  Description: 'Checks array slicing is done with endless ranges when suitable.'
+  Enabled: true
 
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
@@ -313,16 +595,6 @@ Style/StringLiterals:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
   EnforcedStyle: double_quotes
   Enabled: true
-
-Style/StringLiteralsInInterpolation:
-  Description: >-
-                 Checks if uses of quotes inside expressions in interpolated strings
-                 match the configured preference.
-  Enabled: true
-  EnforcedStyle: single_quotes
-  SupportedStyles:
-  - single_quotes
-  - double_quotes
 
 Style/SymbolArray:
   Enabled: false
@@ -386,233 +658,10 @@ Style/WordArray:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: false
 
-Style/OptionHash:
-  Description: Don\'t use option hashes when you can use keyword arguments.
-  SuspiciousParamNames:
-    - options
-    - opts
-    - args
-    - params
-    - parameters
-  Enabled: true
+# rubocop-performance
+# https://github.com/rubocop-hq/rubocop-performance/blob/master/config/default.yml
 
-# Layout
-
-Layout/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
-  Enabled: false
-
-Layout/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
-  EnforcedStyle: trailing
-
-Layout/EmptyLineAfterMagicComment:
-  Description: 'Add an empty line after magic comments to separate them from code.'
-  StyleGuide: '#separate-magic-comments-from-code'
-  Enabled: false
-
-Layout/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
-  Enabled: true
-
-Layout/FirstArrayElementLineBreak:
-  Description: >-
-                 Checks for a line break before the first element in a
-                 multi-line array.
-  Enabled: true
-
-Layout/FirstHashElementLineBreak:
-  Description: >-
-                 Checks for a line break before the first element in a
-                 multi-line hash.
-  Enabled: true
-
-Layout/FirstMethodArgumentLineBreak:
-  Description: >-
-                 Checks for a line break before the first argument in a
-                 multi-line method call.
-  Enabled: true
-
-Layout/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
-  Enabled: false
-
-Layout/MultilineMethodCallIndentation:
-  Description: >-
-                 Checks indentation of method calls with the dot operator
-                 that span more than one line.
-  Enabled: true
-  EnforcedStyle: indented
-
-Layout/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
-  Enabled: true
-  EnforcedStyle: indented
-
-# Lint
-
-Lint/AmbiguousOperator:
-  Description: >-
-                 Checks for ambiguous operators in the first argument of a
-                 method invocation without parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
-  Enabled: false
-
-Lint/AmbiguousRegexpLiteral:
-  Description: >-
-                 Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parenthesis.
-  Enabled: false
-
-Lint/AssignmentInCondition:
-  Description: "Don't use assignment in conditions."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
-  Enabled: false
-
-Lint/CircularArgumentReference:
-  Description: "Don't refer to the keyword argument in the default value."
-  Enabled: true
-
-Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
-  Enabled: false
-
-Lint/DuplicatedKey:
-  Description: 'Check for duplicate keys in hash literals.'
-  Enabled: false
-
-Lint/EachWithObjectArgument:
-  Description: 'Check for immutable argument given to each_with_object.'
-  Enabled: false
-
-Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
-  Enabled: false
-
-Lint/FormatParameterMismatch:
-  Description: 'The number of parameters to format/sprint must match the fields.'
-  Enabled: false
-
-Lint/HandleExceptions:
-  Description: "Don't suppress exception."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
-  Enabled: false
-
-Lint/LiteralAsCondition:
-  Description: 'Checks of literals used in conditions.'
-  Enabled: false
-
-Lint/LiteralInInterpolation:
-  Description: 'Checks for literals used in interpolation.'
-  Enabled: false
-
-Lint/Loop:
-  Description: >-
-                 Use Kernel#loop with break rather than begin/end/until or
-                 begin/end/while for post-loop tests.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
-  Enabled: false
-
-Lint/NestedMethodDefinition:
-  Description: 'Do not use nested method definitions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
-  Enabled: false
-
-Lint/NonLocalExitFromIterator:
-  Description: 'Do not use return in iterator to cause non-local exit.'
-  Enabled: false
-
-Lint/ParenthesesAsGroupedExpression:
-  Description: >-
-                 Checks for method calls with a space before the opening
-                 parenthesis.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
-  Enabled: false
-
-Lint/RequireParentheses:
-  Description: >-
-                 Use parentheses in the method call to avoid confusion
-                 about precedence.
-  Enabled: false
-
-Lint/UnderscorePrefixedVariableName:
-  Description: 'Do not use prefix `_` for a variable that is used.'
-  Enabled: false
-
-Lint/UnneededCopDisableDirective:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
-  Enabled: false
-
-Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
-  Enabled: false
-
-# Metrics
-
-Metrics/AbcSize:
-  Description: >-
-                 A calculated magnitude based on number of assignments,
-                 branches, and conditions.
-  Enabled: false
-
-Metrics/BlockLength:
-  Description: 'Avoid long blocks with many lines.'
-  Enabled: true
-  Exclude:
-    - "gems/**/*_spec.rb"
-    - "spec/**/*"
-    - "config/routes.rb"
-
-Metrics/BlockNesting:
-  Description: 'Avoid excessive block nesting'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
-  Enabled: false
-
-Metrics/ClassLength:
-  Description: 'Avoid classes longer than 100 lines of code.'
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
-  Description: >-
-                 A complexity metric that is strongly correlated to the number
-                 of test cases needed to validate a method.
-  Enabled: false
-
-Metrics/LineLength:
-  Description: 'Limit lines to 100 characters.'
-  Max: 100
-
-Metrics/MethodLength:
-  Description: 'Avoid methods longer than 10 lines of code.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
-  Enabled: false
-
-Metrics/ModuleLength:
-  Description: 'Avoid modules longer than 100 lines of code.'
-  Enabled: false
-
-Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than three or four parameters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
-  Enabled: false
-
-# Performance
-
-Performance/CaseWhenSplat:
-  Description: >-
-                  Place `when` conditions that use splat at the end
-                  of the list of `when` branches.
-  Enabled: false
+# Performance - https://docs.rubocop.org/rubocop-performance/cops_performance.html
 
 Performance/Count:
   Description: >-
@@ -658,56 +707,4 @@ Performance/StringReplacement:
 
 Performance/UnfreezeString:
   Description: 'Use unary plus to get an unfrozen string literal.'
-  Enabled: false
-
-# Rails
-
-Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
-  Enabled: false
-
-Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
-  Enabled: false
-
-Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
-  Enabled: false
-
-Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
-  Enabled: false
-
-Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
-  Enabled: false
-
-Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  Enabled: false
-
-Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
-  Enabled: false
-
-Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  Enabled: false
-
-Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
-  Enabled: false
-
-Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
-  Enabled: false
-
-Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -200,8 +200,8 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
   Enabled: true
+  IgnoredMethods: [task, namespace, describe, context, factory, it]
   Exclude:
-    - !ruby/regexp /spec(\/.*)*\/.*\.rb$/
     - !ruby/regexp /config/routes.rb$/
 
 Metrics/BlockNesting:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Set required ruby version to >= 2.6
 - Replace Travis CI with CircleCI
 - Specify simplecov to be ~> 0.21.0
-- Changed `rubocop` version specification to `~> 1.8.1`
-- Changed `rubocop-performance` version specification to `~> 1.7.0`
+- Change `rubocop` version specification to `~> 1.8.1`
+- Change `rubocop-performance` version specification to `~> 1.7.0`
 
 ### Deprecated
 
@@ -19,7 +19,7 @@
 - Drop support for RBX
 
 ### Fixed
-- Fixed rubocop styling issues
+- Fix rubocop styling issues
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@
 ### Added
 - Support shipments with pickup requests as required for [TNT](https://developers.shipcloud.io/carriers/tnt.html).
 - Add attr_accessor for `email` to class `Shipcloud::Address` to be able to access the email attribute at the address object.
-- Add `rubocop-rake` as a development dependency
-- Add `rubocop-rspec` as a development dependency
 
 ## [0.10.0] - 2019-08-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Set required ruby version to >= 2.6
 - Replace Travis CI with CircleCI
 - Specify simplecov to be ~> 0.21.0
-- Specify `rubocop` to be `~> 1.8.1`
+- Specify `rubocop` to be `~> 1.10.0`
 - Specify `rubocop-performance` to be `~> 1.7.0`
 
 ### Deprecated
@@ -27,6 +27,8 @@
 ### Added
 - Support shipments with pickup requests as required for [TNT](https://developers.shipcloud.io/carriers/tnt.html).
 - Add attr_accessor for `email` to class `Shipcloud::Address` to be able to access the email attribute at the address object.
+- Add `rubocop-rake` as a development dependency
+- Add `rubocop-rspec` as a development dependency
 
 ## [0.10.0] - 2019-08-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Set required ruby version to >= 2.6
 - Replace Travis CI with CircleCI
 - Specify simplecov to be ~> 0.21.0
-- Change `rubocop` version specification to `~> 1.8.1`
-- Change `rubocop-performance` version specification to `~> 1.7.0`
+- Specify `rubocop` to be `~> 1.8.1`
+- Specify `rubocop-performance` to be `~> 1.7.0`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Set required ruby version to >= 2.6
 - Replace Travis CI with CircleCI
 - Specify simplecov to be ~> 0.21.0
+- `rubocop` version is specified to be `~> 1.8.1`
+- `rubocop-performance` version is specified to be `~> 1.7.0`
 
 ### Deprecated
 
@@ -23,16 +25,6 @@
 ### Added
 - Support shipments with pickup requests as required for [TNT](https://developers.shipcloud.io/carriers/tnt.html).
 - Add attr_accessor for `email` to class `Shipcloud::Address` to be able to access the email attribute at the address object.
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 
 ## [0.10.0] - 2019-08-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 - Add attr_accessor for `service` to class `Shipcloud::Shipment` to be able to access the service attribute at the shipment object.
 - Add attr_accessor for `additional_services` to class `Shipcloud::Shipment` to be able to access the additional_services attribute at the shipment object.
 - Add attr_reader for `label_voucher_url` to class `Shipcloud::Shipment` to be able to read the label_voucher_url (QR Code url) attribute at the shipment object.
+- Added missing `frozen_string_literal: true` magic comments to files
 
 ### Changed
 - Set required ruby version to >= 2.6
 - Replace Travis CI with CircleCI
 - Specify simplecov to be ~> 0.21.0
-- `rubocop` version is specified to be `~> 1.8.1`
-- `rubocop-performance` version is specified to be `~> 1.7.0`
+- Changed `rubocop` version specification to `~> 1.8.1`
+- Changed `rubocop-performance` version specification to `~> 1.7.0`
 
 ### Deprecated
 
@@ -18,6 +19,7 @@
 - Drop support for RBX
 
 ### Fixed
+- Fixed rubocop styling issues
 
 ### Security
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in shipcloud.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 require "bundler/gem_tasks"
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :console do
-  require 'irb'
-  require 'irb/completion'
-  require 'shipcloud'
+  require "irb"
+  require "irb/completion"
+  require "shipcloud"
   ARGV.clear
   IRB.start
 end

--- a/lib/shipcloud/address.rb
+++ b/lib/shipcloud/address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class Address < Base
     include Shipcloud::Operations::Update

--- a/lib/shipcloud/base.rb
+++ b/lib/shipcloud/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class Base
     include Shipcloud::Operations::Create
@@ -28,17 +30,15 @@ module Shipcloud
     end
 
     def self.class_name
-      self.name.split("::").last
+      name.split("::").last
     end
 
     def self.base_url
       "#{class_name.downcase}s"
     end
 
-    def self.create_response_root
-    end
+    def self.create_response_root; end
 
-    def self.index_response_root
-    end
+    def self.index_response_root; end
   end
 end

--- a/lib/shipcloud/carrier.rb
+++ b/lib/shipcloud/carrier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class Carrier < Base
     include Shipcloud::Operations::All

--- a/lib/shipcloud/operations/all.rb
+++ b/lib/shipcloud/operations/all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Operations
     module All

--- a/lib/shipcloud/operations/create.rb
+++ b/lib/shipcloud/operations/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Operations
     module Create
@@ -18,7 +20,7 @@ module Shipcloud
           if create_response_root
             response = response.fetch(create_response_root, {})
           end
-          self.new(response)
+          new(response)
         end
       end
 

--- a/lib/shipcloud/operations/delete.rb
+++ b/lib/shipcloud/operations/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Operations
     module Delete

--- a/lib/shipcloud/operations/find.rb
+++ b/lib/shipcloud/operations/find.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Operations
     module Find
@@ -16,7 +18,7 @@ module Shipcloud
             api_key: api_key,
             affiliate_id: affiliate_id,
           )
-          self.new(response)
+          new(response)
         end
       end
 

--- a/lib/shipcloud/operations/update.rb
+++ b/lib/shipcloud/operations/update.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Operations
     module Update
-
       module ClassMethods
         # Updates a object
         # @param [String] id The id of the object that should be updated
@@ -12,7 +13,7 @@ module Shipcloud
           response = Shipcloud.request(
             :put, "#{base_url}/#{id}", attributes, api_key: api_key, affiliate_id: affiliate_id
           )
-          self.new(response)
+          new(response)
         end
       end
 

--- a/lib/shipcloud/pickup_request.rb
+++ b/lib/shipcloud/pickup_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class PickupRequest < Base
     include Shipcloud::Operations::Create

--- a/lib/shipcloud/request/base.rb
+++ b/lib/shipcloud/request/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Request
     class Base

--- a/lib/shipcloud/request/connection.rb
+++ b/lib/shipcloud/request/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Request
     class Connection
@@ -9,12 +11,18 @@ module Shipcloud
 
       def setup_https
         if Shipcloud.configuration.use_ssl
-          @https             = Net::HTTP.new(Shipcloud.configuration.api_base, Net::HTTP.https_default_port)
+          @https = Net::HTTP.new(
+            Shipcloud.configuration.api_base,
+            Net::HTTP.https_default_port,
+          )
           @https.use_ssl     = true
           @https.verify_mode = OpenSSL::SSL::VERIFY_PEER
         else
-          @https             = Net::HTTP.new(Shipcloud.configuration.api_base, Net::HTTP.http_default_port)
-          @https.use_ssl     = false
+          @https = Net::HTTP.new(
+            Shipcloud.configuration.api_base,
+            Net::HTTP.http_default_port,
+          )
+          @https.use_ssl = false
         end
         @https.set_debug_output $stdout if Shipcloud.configuration.debug
       end

--- a/lib/shipcloud/request/info.rb
+++ b/lib/shipcloud/request/info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   module Request
     class Info
@@ -12,16 +14,15 @@ module Shipcloud
       end
 
       def url
-        url = "/#{API_VERSION}/#{api_url}"
-        url
+        "/#{API_VERSION}/#{api_url}"
       end
 
       def path_with_params(path, params)
-        unless params.empty?
+        if params.empty?
+          path
+        else
           encoded_params = URI.encode_www_form(params)
           [path, encoded_params].join("?")
-        else
-          path
         end
       end
     end

--- a/lib/shipcloud/shipcloud_error.rb
+++ b/lib/shipcloud/shipcloud_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class ShipcloudError < StandardError
     attr_reader :errors, :response
@@ -59,10 +61,15 @@ module Shipcloud
 
   # Raised on errors in the 400-499 range
   class ClientError < ShipcloudError; end
+
   class AuthenticationError < ClientError; end
+
   class ForbiddenError < ClientError; end
+
   class InvalidRequestError < ClientError; end
+
   class TooManyRequests < ClientError; end
+
   class NotFoundError < ClientError; end
 
   # Raised on errors in the 500-599 range

--- a/lib/shipcloud/shipment.rb
+++ b/lib/shipcloud/shipment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class Shipment < Base
     include Shipcloud::Operations::Delete

--- a/lib/shipcloud/shipment_quote.rb
+++ b/lib/shipcloud/shipment_quote.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class ShipmentQuote < Base
     include Shipcloud::Operations::Create

--- a/lib/shipcloud/tracker.rb
+++ b/lib/shipcloud/tracker.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Shipcloud
   class Tracker < Base
     include Shipcloud::Operations::All

--- a/lib/shipcloud/version.rb
+++ b/lib/shipcloud/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
-  VERSION = "0.11.0".freeze
+  VERSION = "0.11.0"
 end

--- a/lib/shipcloud/webhook.rb
+++ b/lib/shipcloud/webhook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Shipcloud
   class Webhook < Base
     include Shipcloud::Operations::All

--- a/shipcloud.gemspec
+++ b/shipcloud.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "shipcloud/version"

--- a/shipcloud.gemspec
+++ b/shipcloud.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.6"
-  spec.add_development_dependency "rubocop", "~> 0.71.0"
-  spec.add_development_dependency "rubocop-performance"
+  spec.add_development_dependency "rubocop", "~> 1.8.1"
+  spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "webmock", "~> 3.0"
 end

--- a/shipcloud.gemspec
+++ b/shipcloud.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "shipcloud/version"

--- a/shipcloud.gemspec
+++ b/shipcloud.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.6"
-  spec.add_development_dependency "rubocop", "~> 1.8.1"
+  spec.add_development_dependency "rubocop", "~> 1.10.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "webmock", "~> 3.0"

--- a/spec/shipcloud/address_spec.rb
+++ b/spec/shipcloud/address_spec.rb
@@ -1,42 +1,43 @@
- # encoding: utf-8
-require 'spec_helper'
+# encoding: utf-8
+# frozen_string_literal: true
+require "spec_helper"
 
 describe Shipcloud::Address do
   valid_attributes = {
-    company:     'shipcloud GmbH',
-    first_name:  'Maxi',
-    last_name:   'Musterfrau',
-    care_of:     'Mustermann',
-    street:      'Musterstraße',
-    street_no:   '123',
-    zip_code:    '12345',
-    city:        'Hamburg',
-    state:       'Hamburg',
-    country:     'DE',
-    phone:       '040/123456789',
-    email:       'max@mustermail.com',
+    company: "shipcloud GmbH",
+    first_name: "Maxi",
+    last_name: "Musterfrau",
+    care_of: "Mustermann",
+    street: "Musterstraße",
+    street_no: "123",
+    zip_code: "12345",
+    city: "Hamburg",
+    state: "Hamburg",
+    country: "DE",
+    phone: "040/123456789",
+    email: "max@mustermail.com",
   }
 
-  describe '#initialize' do
-    it 'initializes all attributes correctly' do
+  describe "#initialize" do
+    it "initializes all attributes correctly" do
       address = Shipcloud::Address.new(valid_attributes)
-      expect(address.company).to eq 'shipcloud GmbH'
-      expect(address.first_name).to eq 'Maxi'
-      expect(address.last_name).to eq 'Musterfrau'
-      expect(address.care_of).to eq 'Mustermann'
-      expect(address.street).to eq 'Musterstraße'
-      expect(address.street_no).to eq '123'
-      expect(address.zip_code).to eq '12345'
-      expect(address.city).to eq 'Hamburg'
-      expect(address.state).to eq 'Hamburg'
-      expect(address.country).to eq 'DE'
-      expect(address.phone).to eq '040/123456789'
-      expect(address.email).to eq 'max@mustermail.com'
+      expect(address.company).to eq "shipcloud GmbH"
+      expect(address.first_name).to eq "Maxi"
+      expect(address.last_name).to eq "Musterfrau"
+      expect(address.care_of).to eq "Mustermann"
+      expect(address.street).to eq "Musterstraße"
+      expect(address.street_no).to eq "123"
+      expect(address.zip_code).to eq "12345"
+      expect(address.city).to eq "Hamburg"
+      expect(address.state).to eq "Hamburg"
+      expect(address.country).to eq "DE"
+      expect(address.phone).to eq "040/123456789"
+      expect(address.email).to eq "max@mustermail.com"
     end
   end
 
-  describe '.create' do
-    it 'makes a new POST request using the correct API endpoint' do
+  describe ".create" do
+    it "makes a new POST request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).
         with(:post, "addresses", valid_attributes, api_key: nil, affiliate_id: nil).
         and_return("data" => {})
@@ -65,10 +66,11 @@ describe Shipcloud::Address do
     end
   end
 
-  describe '.find' do
-    it 'makes a new GET request using the correct API endpoint to receive a specific address' do
+  describe ".find" do
+    it "makes a new GET request using the correct API endpoint to receive a specific address" do
       expect(Shipcloud).to receive(:request).with(
-        :get, "addresses/123", {}, api_key: nil, affiliate_id: nil).and_return("id" => "123")
+        :get, "addresses/123", {}, api_key: nil, affiliate_id: nil
+      ).and_return("id" => "123")
 
       Shipcloud::Address.find("123")
     end
@@ -82,8 +84,8 @@ describe Shipcloud::Address do
     end
   end
 
-  describe '.update' do
-    it 'makes a new PUT request using the correct API endpoint' do
+  describe ".update" do
+    it "makes a new PUT request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).with(
         :put, "addresses/123", { street: "Mittelweg" }, api_key: nil, affiliate_id: nil
       ).and_return("data" => {})
@@ -100,15 +102,15 @@ describe Shipcloud::Address do
     end
   end
 
-  describe '.all' do
-    it 'makes a new Get request using the correct API endpoint' do
+  describe ".all" do
+    it "makes a new Get request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).
         with(:get, "addresses", {}, api_key: nil, affiliate_id: nil).and_return([])
 
       Shipcloud::Address.all
     end
 
-    it 'returns a list of Address objects' do
+    it "returns a list of Address objects" do
       stub_addresses_request
 
       addresses = Shipcloud::Address.all
@@ -146,7 +148,7 @@ describe Shipcloud::Address do
             "city" => "Musterstadt",
             "state" => "",
             "country" => "DE",
-            "phone" => ""
+            "phone" => "",
           },
           {
             "id" => "7ea2a290-b456-4ecf-9010-e82b3da298f0",
@@ -160,9 +162,9 @@ describe Shipcloud::Address do
             "city" => "Musterstadt",
             "state" => "",
             "country" => "DE",
-            "phone" => ""
-          }
-        ]
+            "phone" => "",
+          },
+        ],
       )
   end
 

--- a/spec/shipcloud/carrier_spec.rb
+++ b/spec/shipcloud/carrier_spec.rb
@@ -1,35 +1,36 @@
-require 'spec_helper'
+# frozen_string_literal: true
+require "spec_helper"
 
 describe Shipcloud::Carrier do
-  describe '#initialize' do
-    it 'initializes all attributes correctly' do
+  describe "#initialize" do
+    it "initializes all attributes correctly" do
       valid_attributes = {
-        name: 'bogus',
-        display_name: 'Bogus Carrier',
-        services: %w(
-          standard,
-          returns,
-          one_day,
-          one_day_early
-        )
+        name: "bogus",
+        display_name: "Bogus Carrier",
+        services: [
+          "standard",
+          "returns",
+          "one_day",
+          "one_day_early",
+        ],
       }
       carrier = Shipcloud::Carrier.new(valid_attributes)
 
-      expect(carrier.name).to eq 'bogus'
-      expect(carrier.display_name).to eq 'Bogus Carrier'
-      expect(carrier.services).to eq %w(standard, returns, one_day, one_day_early)
+      expect(carrier.name).to eq "bogus"
+      expect(carrier.display_name).to eq "Bogus Carrier"
+      expect(carrier.services).to eq ["standard", "returns", "one_day", "one_day_early"]
     end
   end
 
-  describe '.all' do
-    it 'makes a new Get request using the correct API endpoint' do
+  describe ".all" do
+    it "makes a new Get request using the correct API endpoint" do
       expect(Shipcloud).to receive(:request).
         with(:get, "carriers", {}, api_key: nil, affiliate_id: nil).and_return([])
 
       Shipcloud::Carrier.all
     end
 
-    it 'returns a list of Carrier objects' do
+    it "returns a list of Carrier objects" do
       stub_carriers_request
 
       carriers = Shipcloud::Carrier.all
@@ -39,31 +40,31 @@ describe Shipcloud::Carrier do
       end
     end
 
-    it 'initializes the Carrier objects correctly' do
+    it "initializes the Carrier objects correctly" do
       stub_carriers_request
       allow(Shipcloud::Carrier).to receive(:new)
 
       Shipcloud::Carrier.all
 
-      expect(Shipcloud::Carrier).to have_received(:new)
-        .with(
-          'name' => 'carrier_1',
-          'display_name' => 'Carrier 1',
-          'services' => %w(
-            standard,
-            returns,
-            one_day,
-            one_day_early
-          )
+      expect(Shipcloud::Carrier).to have_received(:new).
+        with(
+          "name" => "carrier_1",
+          "display_name" => "Carrier 1",
+          "services" => [
+            "standard",
+            "returns",
+            "one_day",
+            "one_day_early",
+          ],
         )
-      expect(Shipcloud::Carrier).to have_received(:new)
-        .with(
-          'name' => 'carrier_2',
-          'display_name' => 'Carrier 2',
-          'services' => %w(
-            standard,
-            returns
-          )
+      expect(Shipcloud::Carrier).to have_received(:new).
+        with(
+          "name" => "carrier_2",
+          "display_name" => "Carrier 2",
+          "services" => [
+            "standard",
+            "returns",
+          ],
         )
     end
 
@@ -81,24 +82,24 @@ describe Shipcloud::Carrier do
       and_return(
         [
           {
-            'name' => 'carrier_1',
-            'display_name' => 'Carrier 1',
-            'services' => %w(
-              standard,
-              returns,
-              one_day,
-              one_day_early
-            )
+            "name" => "carrier_1",
+            "display_name" => "Carrier 1",
+            "services" => [
+              "standard",
+              "returns",
+              "one_day",
+              "one_day_early",
+            ],
           },
           {
-            'name' => 'carrier_2',
-            'display_name' => 'Carrier 2',
-            'services' => %w(
-              standard,
-              returns
-            )
-          }
-        ]
+            "name" => "carrier_2",
+            "display_name" => "Carrier 2",
+            "services" => [
+              "standard",
+              "returns",
+            ],
+          },
+        ],
       )
   end
 end

--- a/spec/shipcloud/pickup_request_spec.rb
+++ b/spec/shipcloud/pickup_request_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::PickupRequest do
@@ -5,18 +6,18 @@ describe Shipcloud::PickupRequest do
     carrier: "dpd",
     pickup_time: {
       earliest: "2015-09-15T09:00:00+02:00",
-      latest: "2015-09-15T18:00:00+02:00"
+      latest: "2015-09-15T18:00:00+02:00",
     },
     shipments: [
-      { id: "abc_123" }
-    ]
+      { id: "abc_123" },
+    ],
   }
 
   valid_attributes_with_pickup_address = {
     carrier: "dpd",
     pickup_time: {
       earliest: "2015-09-15T09:00:00+02:00",
-      latest: "2015-09-15T18:00:00+02:00"
+      latest: "2015-09-15T18:00:00+02:00",
     },
     pickup_address: {
       company: "Muster-Company",
@@ -27,11 +28,11 @@ describe Shipcloud::PickupRequest do
       zip_code: "54321",
       city: "Musterstadt",
       country: "DE",
-      phone: "555-555"
+      phone: "555-555",
     },
     shipments: [
-      { id: "abc_123" }
-    ]
+      { id: "abc_123" },
+    ],
   }
 
   describe "#initialize" do
@@ -70,8 +71,8 @@ describe Shipcloud::PickupRequest do
           "carrier" => "dpd",
           "pickup_time" => {
             "earliest" => "2015-09-15T09:00:00+02:00",
-            "latest" => "2015-09-15T18:00:00+02:00"
-          }
+            "latest" => "2015-09-15T18:00:00+02:00",
+          },
         )
 
       pickup_request = Shipcloud::PickupRequest.create(valid_attributes)
@@ -88,7 +89,7 @@ describe Shipcloud::PickupRequest do
           "carrier" => "dpd",
           "pickup_time" => {
             "earliest" => "2015-09-15T09:00:00+02:00",
-            "latest" => "2015-09-15T18:00:00+02:00"
+            "latest" => "2015-09-15T18:00:00+02:00",
           },
           "pickup_address" => {
             "id" => "522a7cb1-d6c8-418c-ac26-011127ab5bbe",
@@ -100,8 +101,8 @@ describe Shipcloud::PickupRequest do
             "zip_code" => "54321",
             "city" => "Musterstadt",
             "country" => "DE",
-            "phone" => "555-555"
-          }
+            "phone" => "555-555",
+          },
         )
 
       pickup_request = Shipcloud::PickupRequest.create(valid_attributes_with_pickup_address)
@@ -116,7 +117,7 @@ describe Shipcloud::PickupRequest do
         "zip_code" => "54321",
         "city" => "Musterstadt",
         "country" => "DE",
-        "phone" => "555-555"
+        "phone" => "555-555",
       )
     end
 

--- a/spec/shipcloud/request/base_spec.rb
+++ b/spec/shipcloud/request/base_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::Request::Base do
@@ -5,9 +6,9 @@ describe Shipcloud::Request::Base do
     it "checks for an api key" do
       info = Shipcloud::Request::Info.new(:get, "shipments", nil, {}, "affiliate_id")
 
-      expect{
+      expect do
         Shipcloud::Request::Base.new(info).perform
-      }.to raise_error Shipcloud::AuthenticationError
+      end.to raise_error Shipcloud::AuthenticationError
     end
 
     it "performs an https request and returns a response hash" do

--- a/spec/shipcloud/request/connection_spec.rb
+++ b/spec/shipcloud/request/connection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::Request::Connection do

--- a/spec/shipcloud/shipcloud_error_spec.rb
+++ b/spec/shipcloud/shipcloud_error_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::ShipcloudError do
@@ -5,7 +6,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with status code 400" do
       it "returns a Shipcloud::InvalidRequestError" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 400))).to be_a(
-          Shipcloud::InvalidRequestError
+          Shipcloud::InvalidRequestError,
         )
       end
     end
@@ -13,7 +14,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with status code 422" do
       it "returns a Shipcloud::InvalidRequestError" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 422))).to be_a(
-          Shipcloud::InvalidRequestError
+          Shipcloud::InvalidRequestError,
         )
       end
     end
@@ -21,7 +22,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with status code 401" do
       it "returns a Shipcloud::AuthenticationError" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 401))).to be_a(
-          Shipcloud::AuthenticationError
+          Shipcloud::AuthenticationError,
         )
       end
     end
@@ -29,7 +30,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with status code 402" do
       it "returns a Shipcloud::TooManyRequests" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 402))).to be_a(
-          Shipcloud::TooManyRequests
+          Shipcloud::TooManyRequests,
         )
       end
     end
@@ -37,7 +38,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with status code 404" do
       it "returns a Shipcloud::NotFoundError" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 404))).to be_a(
-          Shipcloud::NotFoundError
+          Shipcloud::NotFoundError,
         )
       end
     end
@@ -45,7 +46,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with a 4xx status code" do
       it "returns a Shipcloud::ClientError" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 400))).to be_a(
-          Shipcloud::ClientError
+          Shipcloud::ClientError,
         )
       end
     end
@@ -53,7 +54,7 @@ describe Shipcloud::ShipcloudError do
     context "with a response with a 5xx status code" do
       it "returns a Shipcloud::ClientError" do
         expect(Shipcloud::ShipcloudError.from_response(build_response(status_code: 500))).to be_a(
-          Shipcloud::ServerError
+          Shipcloud::ServerError,
         )
       end
     end

--- a/spec/shipcloud/shipment_quote_spec.rb
+++ b/spec/shipcloud/shipment_quote_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::ShipmentQuote do
@@ -22,8 +23,8 @@ describe Shipcloud::ShipmentQuote do
       weight: 2.5,
       length: 40,
       width: 20,
-      height: 20
-    }
+      height: 20,
+    },
   }
 
   describe "#initialize" do
@@ -62,8 +63,8 @@ describe Shipcloud::ShipmentQuote do
       allow(Shipcloud).to receive(:request).
         and_return(
           "shipment_quote" => {
-            "price" => 42.12
-          }
+            "price" => 42.12,
+          },
         )
 
       shipment_quote = Shipcloud::ShipmentQuote.create(valid_attributes)

--- a/spec/shipcloud/shipment_spec.rb
+++ b/spec/shipcloud/shipment_spec.rb
@@ -61,9 +61,9 @@ describe Shipcloud::Shipment do
             bank_account_number: "DE12500105170648489890",
             bank_code: "BENEDEPPYYY",
             reference1: "reason for transfer",
-          }
-        }
-      ]
+          },
+        },
+      ],
     }
   end
 

--- a/spec/shipcloud/shipment_spec.rb
+++ b/spec/shipcloud/shipment_spec.rb
@@ -2,77 +2,10 @@
 require "spec_helper"
 
 describe Shipcloud::Shipment do
-  let(:valid_attributes) do
-    {
-      to: {
-        company: "shipcloud GmbH",
-        first_name: "Max",
-        last_name: "Mustermann",
-        street: "Musterallee",
-        street_no: "43",
-        city: "Berlin",
-        zip_code: "10000",
-      },
-      carrier: "dhl",
-      service: "standard",
-      package: {
-        weight: 2.5,
-        length: 40,
-        width: 20,
-        height: 20,
-      },
-      pickup: {
-        pickup_time: {
-          earliest: "2015-09-15T09:00:00+02:00",
-          latest: "2015-09-15T18:00:00+02:00",
-        },
-        pickup_address: {
-          company: "Sender Ltd.",
-          first_name: "Jane",
-          last_name: "Doe",
-          street: "Musterstraße",
-          street_no: "42",
-          zip_code: "54321",
-          city: "Musterstadt",
-          country: "DE",
-        },
-      },
-      metadata: {
-        product: {
-          name: "foo",
-        },
-        category: {
-          id: "123456",
-          name: "bar",
-        },
-      },
-      customs_declaration: {
-        id: "123456",
-        contents_type: "commercial_goods",
-      },
-      additional_services: [
-        {
-          name: "cash_on_delivery",
-          properties: {
-            amount: 123.45,
-            currency: "EUR",
-            bank_account_holder: "Max Mustermann",
-            bank_name: "Musterbank",
-            bank_account_number: "DE12500105170648489890",
-            bank_code: "BENEDEPPYYY",
-            reference1: "reason for transfer",
-          },
-        },
-      ],
-    }
-  end
-
-  let(:shipment) do
-    Shipcloud::Shipment.new(valid_attributes)
-  end
-
   describe "#initialize" do
     it "initializes all attributes correctly" do
+      shipment = Shipcloud::Shipment.new(valid_attributes)
+
       expect(shipment.to[:company]).to eq "shipcloud GmbH"
       expect(shipment.to[:first_name]).to eq "Max"
       expect(shipment.to[:last_name]).to eq "Mustermann"
@@ -119,6 +52,8 @@ describe Shipcloud::Shipment do
     end
 
     it "initializes the metadata correctly" do
+      shipment = Shipcloud::Shipment.new(valid_attributes)
+
       metadata = {
         category: {
           id: "123456",
@@ -335,5 +270,70 @@ describe Shipcloud::Shipment do
         },
       },
     ]
+  end
+
+  def valid_attributes
+    {
+      to: {
+        company: "shipcloud GmbH",
+        first_name: "Max",
+        last_name: "Mustermann",
+        street: "Musterallee",
+        street_no: "43",
+        city: "Berlin",
+        zip_code: "10000",
+      },
+      carrier: "dhl",
+      service: "standard",
+      package: {
+        weight: 2.5,
+        length: 40,
+        width: 20,
+        height: 20,
+      },
+      pickup: {
+        pickup_time: {
+          earliest: "2015-09-15T09:00:00+02:00",
+          latest: "2015-09-15T18:00:00+02:00",
+        },
+        pickup_address: {
+          company: "Sender Ltd.",
+          first_name: "Jane",
+          last_name: "Doe",
+          street: "Musterstraße",
+          street_no: "42",
+          zip_code: "54321",
+          city: "Musterstadt",
+          country: "DE",
+        },
+      },
+      metadata: {
+        product: {
+          name: "foo",
+        },
+        category: {
+          id: "123456",
+          name: "bar",
+        },
+      },
+      customs_declaration: {
+        id: "123456",
+        contents_type: "commercial_goods",
+      },
+      additional_services: [
+        {
+          name: "cash_on_delivery",
+          properties: {
+            amount: 123.45,
+            currency: "EUR",
+            bank_account_holder: "Max Mustermann",
+            bank_name: "Musterbank",
+            bank_account_number: "DE12500105170648489890",
+            bank_code: "BENEDEPPYYY",
+            reference1: "reason for transfer",
+          },
+        },
+      ],
+    }
   end
 end

--- a/spec/shipcloud/shipment_spec.rb
+++ b/spec/shipcloud/shipment_spec.rb
@@ -1,29 +1,30 @@
-require 'spec_helper'
+# frozen_string_literal: true
+require "spec_helper"
 
 describe Shipcloud::Shipment do
   let(:valid_attributes) do
     {
       to: {
-        company: 'shipcloud GmbH',
-        first_name:   'Max',
-        last_name: 'Mustermann',
-        street: 'Musterallee',
-        street_no: '43',
-        city: 'Berlin',
-        zip_code: '10000',
+        company: "shipcloud GmbH",
+        first_name: "Max",
+        last_name: "Mustermann",
+        street: "Musterallee",
+        street_no: "43",
+        city: "Berlin",
+        zip_code: "10000",
       },
-      carrier: 'dhl',
-      service: 'standard',
+      carrier: "dhl",
+      service: "standard",
       package: {
         weight: 2.5,
         length: 40,
         width: 20,
-        height: 20
+        height: 20,
       },
       pickup: {
         pickup_time: {
           earliest: "2015-09-15T09:00:00+02:00",
-          latest: "2015-09-15T18:00:00+02:00"
+          latest: "2015-09-15T18:00:00+02:00",
         },
         pickup_address: {
           company: "Sender Ltd.",
@@ -33,17 +34,17 @@ describe Shipcloud::Shipment do
           street_no: "42",
           zip_code: "54321",
           city: "Musterstadt",
-          country: "DE"
-         },
+          country: "DE",
+        },
       },
       metadata: {
         product: {
-          name: "foo"
+          name: "foo",
         },
         category: {
           id: "123456",
-          name: "bar"
-        }
+          name: "bar",
+        },
       },
       customs_declaration: {
         id: "123456",
@@ -66,22 +67,22 @@ describe Shipcloud::Shipment do
     }
   end
 
-  let(:shipment) {
+  let(:shipment) do
     Shipcloud::Shipment.new(valid_attributes)
-  }
+  end
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      expect(shipment.to[:company]).to eq 'shipcloud GmbH'
-      expect(shipment.to[:first_name]).to eq 'Max'
-      expect(shipment.to[:last_name]).to eq 'Mustermann'
-      expect(shipment.to[:street]).to eq 'Musterallee'
-      expect(shipment.to[:street_no]).to eq '43'
-      expect(shipment.to[:city]).to eq 'Berlin'
-      expect(shipment.to[:zip_code]).to eq '10000'
+      expect(shipment.to[:company]).to eq "shipcloud GmbH"
+      expect(shipment.to[:first_name]).to eq "Max"
+      expect(shipment.to[:last_name]).to eq "Mustermann"
+      expect(shipment.to[:street]).to eq "Musterallee"
+      expect(shipment.to[:street_no]).to eq "43"
+      expect(shipment.to[:city]).to eq "Berlin"
+      expect(shipment.to[:zip_code]).to eq "10000"
 
-      expect(shipment.carrier).to eq 'dhl'
-      expect(shipment.service).to eq 'standard'
+      expect(shipment.carrier).to eq "dhl"
+      expect(shipment.service).to eq "standard"
 
       expect(shipment.package[:weight]).to eq 2.5
       expect(shipment.package[:length]).to eq 40
@@ -121,11 +122,11 @@ describe Shipcloud::Shipment do
       metadata = {
         category: {
           id: "123456",
-          name: "bar"
+          name: "bar",
         },
         product: {
-          name: "foo"
-        }
+          name: "foo",
+        },
       }
 
       expect(shipment.metadata).to eq metadata
@@ -154,7 +155,8 @@ describe Shipcloud::Shipment do
   end
 
   describe ".find" do
-    it "makes a new GET request using the correct API endpoint to receive a specific subscription" do
+    it "makes a new GET request using the correct API endpoint " \
+       "to receive a specific subscription" do
       expect(Shipcloud).to receive(:request).
         with(:get, "shipments/123", {}, api_key: nil, affiliate_id: nil).
         and_return("id" => "123")
@@ -264,7 +266,8 @@ describe Shipcloud::Shipment do
 
   def shipments_array
     [
-      { "id" => "86afb143f9c9c0cfd4eb7a7c26a5c616585a6271",
+      {
+        "id" => "86afb143f9c9c0cfd4eb7a7c26a5c616585a6271",
         "carrier_tracking_no" => "43128000105",
         "carrier" => "hermes",
         "service" => "standard",
@@ -278,7 +281,7 @@ describe Shipcloud::Shipment do
           "street_no" => "1",
           "zip_code" => "12345",
           "city" => "Hamburg",
-          "country" => "DE"
+          "country" => "DE",
         },
         "from" => {
           "company" => "webionate GmbH",
@@ -287,17 +290,18 @@ describe Shipcloud::Shipment do
           "street_no" => "35a",
           "zip_code" => "22175",
           "city" => "Hamburg",
-          "country" => "DE"
+          "country" => "DE",
         },
         "packages" => {
           "id" => "be81573799958587ae891b983aabf9c4089fc462",
           "length" => 10.0,
           "width" => 10.0,
           "height" => 10.0,
-          "weight" => 1.5
-        }
+          "weight" => 1.5,
+        },
       },
-      { "id" => "be81573799958587ae891b983aabf9c4089fc462",
+      {
+        "id" => "be81573799958587ae891b983aabf9c4089fc462",
         "carrier_tracking_no" => "1Z12345E1305277940",
         "carrier" => "ups",
         "service" => "standard",
@@ -311,7 +315,7 @@ describe Shipcloud::Shipment do
           "street_no" => "57",
           "zip_code" => "22081",
           "city" => "Hamburg",
-          "country" => "DE"
+          "country" => "DE",
         },
         "from" => {
           "company" => "webionate GmbH",
@@ -320,16 +324,16 @@ describe Shipcloud::Shipment do
           "street_no" => "35a",
           "zip_code" => "22175",
           "city" => "Hamburg",
-          "country" => "DE"
+          "country" => "DE",
         },
         "packages" => {
           "id" => "74d4f1fc193d8a7ca542d1ee4e2021f3ddb82242",
           "length" => 15.0,
           "width" => 20.0,
           "height" => 10.0,
-          "weight" => 2.0
-        }
-      }
+          "weight" => 2.0,
+        },
+      },
     ]
   end
 end

--- a/spec/shipcloud/webhooks_spec.rb
+++ b/spec/shipcloud/webhooks_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud::Webhook do
   valid_attributes = {
     id: "583cfd8b-77c7-4447-a3a0-1568bb9cc553",
     url: "https://example.com/webhook",
-    event_types: ["shipment.tracking.delayed", "shipment.tracking.delivered"]
+    event_types: ["shipment.tracking.delayed", "shipment.tracking.delivered"],
   }
 
   describe "#initialize" do
@@ -126,14 +127,14 @@ describe Shipcloud::Webhook do
         "id" => "583cfd8b-77c7-4447-a3a0-1568bb9cc553",
         "url" => "https://example.com/webhook",
         "event_types" => ["shipment.tracking.delayed", "shipment.tracking.delivered"],
-        "deactivated" => false
+        "deactivated" => false,
       },
       {
         "id" => "e0ff4250-6c8e-494d-a069-afd9d566e372",
         "url" => "https://example.com/webhook",
         "event_types" => ["shipment.tracking.delayed", "shipment.tracking.delivered"],
-        "deactivated" => false
-      }
+        "deactivated" => false,
+      },
     ]
   end
 end

--- a/spec/shipcloud_spec.rb
+++ b/spec/shipcloud_spec.rb
@@ -1,16 +1,19 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Shipcloud do
   describe ".request" do
     context "given no api key exists" do
       it "raises an authentication error" do
-        expect { Shipcloud.request(:get, "clients", {}) }.to raise_error(Shipcloud::AuthenticationError)
+        expect do
+          Shipcloud.request(:get, "clients", {})
+        end.to raise_error(Shipcloud::AuthenticationError)
       end
     end
 
     context "with an invalid api key" do
       before(:each) do
-        WebMock.stub_request(:any, /#{Shipcloud.configuration.api_base}/).to_return(:body => "{}")
+        WebMock.stub_request(:any, /#{Shipcloud.configuration.api_base}/).to_return(body: "{}")
         Shipcloud.api_key = "your-api-key"
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 require "simplecov"
 SimpleCov.start
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-require 'shipcloud'
-require 'rspec'
+require "shipcloud"
+require "rspec"
 require "webmock/rspec"
 require "pry"
 


### PR DESCRIPTION
* Change `rubocop` version specification to `~> 1.8.1`
* Change `rubocop-performance` version specification to `~> 1.7.0`
* Update `.rubocop.yml` to match current shipcloud style guides
* Correct styling issues automatically with `rubocop -a`
* Fix remaining styling issues, mostly by adding magic comment
`# frozen_string_literal: true` to files

[ch7626](https://app.clubhouse.io/shipcloud/story/7626)