### PR TITLE
Ensure compatibility with ruby 2.x and 3.x

### DIFF
--- a/lib/shipcloud/operations/update.rb
+++ b/lib/shipcloud/operations/update.rb
@@ -4,14 +4,20 @@ module Shipcloud
   module Operations
     module Update
       module ClassMethods
-        # Updates a object
+        # Updates an object
         # @param [String] id The id of the object that should be updated
         # @param [Hash] attributes The attributes that should be updated
-        # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+        # @param [String] optional api_key The api key. If no api key is given, Shipcloud.api_key
         # will be used for the request
-        def update(id, attributes, api_key: nil, affiliate_id: nil)
+        # @param [String] optional affiliate_id Your affiliate ID. If no affiliate ID is given,
+        # Shipcloud.affiliate_id will be used for the request
+        def update(id, attributes = {}, **kwargs)
+          attributes.merge!(kwargs)
+          options = attributes.slice(:api_key, :affiliate_id) || {}
+          attributes.reject! { |key| [:api_key, :affiliate_id].include?(key) }
           response = Shipcloud.request(
-            :put, "#{base_url}/#{id}", attributes, api_key: api_key, affiliate_id: affiliate_id
+            :put, "#{base_url}/#{id}", attributes,
+            api_key: options[:api_key], affiliate_id: options[:affiliate_id]
           )
           new(response)
         end
@@ -21,16 +27,15 @@ module Shipcloud
         base.extend(ClassMethods)
       end
 
-      # Updates a object
+      # Updates an object
       #
       # @param [Hash] attributes The attributes that should be updated
-      # @param \[String\] optional api_key The api key. If no api key is given, Shipcloud.api_key
+      # @param [String] optional api_key The api key. If no api key is given, Shipcloud.api_key
       # will be used for the request
-      def update(attributes, api_key: nil, affiliate_id: nil)
-        response = Shipcloud.request(
-          :put, "#{base_url}/#{id}", attributes, api_key: api_key, affiliate_id: affiliate_id
-        )
-        set_attributes(response)
+      # @param [String] optional affiliate_id Your affiliate ID. If no affiliate ID is given,
+      # Shipcloud.affiliate_id will be used for the request
+      def update(attributes = {}, **kwargs)
+        self.class.update(id, attributes, **kwargs)
       end
     end
   end

--- a/spec/shipcloud/address_spec.rb
+++ b/spec/shipcloud/address_spec.rb
@@ -131,6 +131,28 @@ describe Shipcloud::Address do
     end
   end
 
+  describe "#update" do
+    it "makes a new PUT request using the correct API endpoint" do
+      expect(Shipcloud).to receive(:request).with(
+        :put, "addresses/123", { street: "Mittelweg" }, api_key: nil, affiliate_id: nil
+      ).and_return("data" => {})
+
+      address = Shipcloud::Address.new(id: "123")
+
+      address.update(street: "Mittelweg")
+    end
+
+    it "uses the affiliate ID provided for the request" do
+      expect(Shipcloud).to receive(:request).with(
+        :put, "addresses/123", { street: "Mittelweg" }, api_key: nil, affiliate_id: "affiliate_id"
+      ).and_return("data" => {})
+
+      address = Shipcloud::Address.new(id: "123")
+
+      address.update({ street: "Mittelweg" }, affiliate_id: "affiliate_id")
+    end
+  end
+
   def stub_addresses_request(affiliate_id: nil)
     allow(Shipcloud).to receive(:request).
       with(:get, "addresses", {}, api_key: nil, affiliate_id: affiliate_id).

--- a/spec/shipcloud/shipment_spec.rb
+++ b/spec/shipcloud/shipment_spec.rb
@@ -193,6 +193,29 @@ describe Shipcloud::Shipment do
     end
   end
 
+  describe "#update" do
+    it "makes a new PUT request using the correct API endpoint" do
+      expect(Shipcloud).to receive(:request).
+        with(:put, "shipments/123", { carrier: "ups" }, api_key: nil, affiliate_id: nil).
+        and_return("data" => {})
+
+      shipment = Shipcloud::Shipment.new(id: "123")
+
+      shipment.update(carrier: "ups")
+    end
+
+    it "uses the affiliate ID provided for the request" do
+      expect(Shipcloud).to receive(:request).
+        with(
+          :put, "shipments/123", { carrier: "ups" }, api_key: nil, affiliate_id: "affiliate_id"
+        ).and_return("data" => {})
+
+      shipment = Shipcloud::Shipment.new(id: "123")
+
+      shipment.update({ carrier: "ups" }, affiliate_id: "affiliate_id")
+    end
+  end
+
   def stub_shipments_requests(affiliate_id: nil)
     allow(Shipcloud).to receive(:request).
       with(:get, "shipments", {}, api_key: nil, affiliate_id: affiliate_id).


### PR DESCRIPTION
We were affected by the change in positional keyword arguments for ruby 3.x, so we need to change the `.update` and `#update` implementations slightly to be compatible with ruby 2.x and 3.x.

[sc-14935](https://app.shortcut.com/shipcloud/story/14935)