### PR TITLE
Add attribute reader for carrier tracking url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add attr_accessor for `additional_services` to class `Shipcloud::Shipment` to be able to access the additional_services attribute at the shipment object.
 - Add attr_reader for `label_voucher_url` to class `Shipcloud::Shipment` to be able to read the label_voucher_url (QR Code url) attribute at the shipment object.
 - Added missing `frozen_string_literal: true` magic comments to files
+- Add attr_reader for `carrier_tracking_url` to class `Shipcloud::Shipment` to be able to read the carrier_tracking_url attribute at the shipment object.
 
 ### Changed
 - Ensure compatibility with ruby 2.x and 3.x

--- a/lib/shipcloud/shipment.rb
+++ b/lib/shipcloud/shipment.rb
@@ -8,8 +8,9 @@ module Shipcloud
 
     attr_accessor :from, :to, :carrier, :service, :package, :reference_number, :metadata,
                   :additional_services
-    attr_reader :id, :created_at, :carrier_tracking_no, :tracking_url, :label_url, :carrier_tracking_url,
-                :packages, :price, :customs_declaration, :pickup, :label_voucher_url
+    attr_reader :id, :created_at, :carrier_tracking_no, :tracking_url, :label_url,
+                :packages, :price, :customs_declaration, :pickup,
+                :label_voucher_url, :carrier_tracking_url
 
     def self.index_response_root
       "#{class_name.downcase}s"

--- a/lib/shipcloud/shipment.rb
+++ b/lib/shipcloud/shipment.rb
@@ -8,7 +8,7 @@ module Shipcloud
 
     attr_accessor :from, :to, :carrier, :service, :package, :reference_number, :metadata,
                   :additional_services
-    attr_reader :id, :created_at, :carrier_tracking_no, :tracking_url, :label_url,
+    attr_reader :id, :created_at, :carrier_tracking_no, :tracking_url, :label_url, :carrier_tracking_url,
                 :packages, :price, :customs_declaration, :pickup, :label_voucher_url
 
     def self.index_response_root


### PR DESCRIPTION
The carrier tracking url is generated but is inaccessible on the Shipment Object. This commit provides a fix.