### PR TITLE
readme fix: Shipment.all – pass parameters as a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ shipment.tracking_url # -> http://track.shipcloud.io/uzdgu22z3ed12
 You can get a list of all shipments from the shipcloud platform. Shipments can be filtered by providing optional parameters. For more information and a list of valid parameters see *[shipcloud API documentation on Shipments Index](https://developers.shipcloud.io/reference/#getting-a-list-of-shipments)*
 
 ```ruby
-Shipcloud::Shipment.all(
+Shipcloud::Shipment.all({
   carrier: 'ups',
   per_page: 25,
   page: 2
-)
+})
 ```
 
 `Shipment#all` will return an array of `Shipcloud::Shipment` objects, matching the given parameters.


### PR DESCRIPTION
Replaced this

```ruby
Shipcloud::Shipment.all(
  carrier: 'ups',
  per_page: 25,
  page: 2
)
```

with this

```ruby
Shipcloud::Shipment.all({
  carrier: 'ups',
  per_page: 25,
  page: 2
})
```

since otherwise you will get an ArgumentError